### PR TITLE
v1.2.1 - Feature: add selectCharCodeTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,38 @@
+## 1.2.1
+
+- `PrinterDocument`:
+  - `print`: added optional parameter `selectCharCodeTable` to select character code table before printing.
+
+- `GenericPrinter`:
+  - Added method `selectCharCodeTable({int codeTable = 0})` to send ESC/POS command to select character code table.
+
+- `Generator` (abstract):
+  - Added methods and properties for character code table support:
+    - `selectCharCodeTable({int codeTable = 0})`
+    - `int? get selectedCharCodeTable`
+    - `String? get selectedCharset`
+    - `CharsetEncoder? get selectedCharsetEncoder`
+
+- `GeneratorEscPos`:
+  - Implemented character code table selection and tracking:
+    - `_selectedCharCodeTable`, `_selectedCharset`, `_selectedCharsetEncoder` fields.
+    - `selectCharCodeTable` updates selected table and charset encoder.
+    - `reset` clears selected character code table.
+  - Added enum `CharCodeTableEscPos` mapping ESC/POS code tables to charset names and encoders.
+  - Updated text encoding to use selected charset encoder if available.
+
+- `char_encoder.dart`:
+  - Added comprehensive charset encoder resolution via `getCharsetEncoder(String? name)` using `charset` package.
+  - Updated `encodeChars` to accept optional `CharsetEncoder` or charset name and fallback to latin1 or utf8 if encoding fails.
+
+- Dependency updates:
+  - Added `charset: ^2.0.1`
+  - Updated `image` to ^4.7.2
+  - Updated `collection` to ^1.19.1
+  - Updated `test` to ^1.29.0
+  - Updated `dependency_validator` to ^5.0.3
+  - Updated `coverage` to ^1.15.0
+
 ## 1.2.0
 
 - Migrate to `image: ^4.5.4`.

--- a/lib/src/esc_pos_base.dart
+++ b/lib/src/esc_pos_base.dart
@@ -58,11 +58,16 @@ class PrinterDocument {
   /// - [endJob]: If `true` (default), calls [printer.endJob()] after printing.
   ///
   /// Skips execution if there are no commands.
-  void print(GenericPrinter printer, {bool reset = true, bool endJob = true}) {
+  void print(GenericPrinter printer,
+      {bool reset = true, int? selectCharCodeTable, bool endJob = true}) {
     if (commands.isEmpty) return;
 
     if (reset) {
       printer.reset();
+    }
+
+    if (selectCharCodeTable != null) {
+      printer.selectCharCodeTable(codeTable: selectCharCodeTable);
     }
 
     for (var c in commands) {

--- a/lib/src/printer/generic_printer.dart
+++ b/lib/src/printer/generic_printer.dart
@@ -46,6 +46,10 @@ abstract class GenericPrinter {
     writeBytes(_generator.reset());
   }
 
+  void selectCharCodeTable({int codeTable = 0}) {
+    writeBytes(_generator.selectCharCodeTable(codeTable: codeTable));
+  }
+
   void endJob() {
     writeBytes(_generator.endJob());
   }

--- a/lib/src/utils/char_encoder.dart
+++ b/lib/src/utils/char_encoder.dart
@@ -1,9 +1,144 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
-/// Encodes the `String` [s] into bytes. Attempts to encode using [latin1],
-/// and, in case of an error, falls back to [utf8].
-Uint8List encodeChars(String s) {
+import 'package:charset/charset.dart' as charset;
+
+typedef CharsetEncoder = Converter<String, List<int>>;
+
+CharsetEncoder? getCharsetEncoder(String? name) {
+  if (name == null) return null;
+  name = name.trim().toLowerCase();
+  if (name.isEmpty) return null;
+
+  switch (name) {
+    case 'latin-2':
+      return charset.latin2.encoder;
+    case 'latin-3':
+      return charset.latin3.encoder;
+    case 'latin-4':
+      return charset.latin4.encoder;
+    case 'cyrillic':
+      return charset.latinCyrillic.encoder;
+    case 'arabic':
+      return charset.latinArabic.encoder;
+    case 'greek':
+      return charset.latinGreek.encoder;
+    case 'hebrew':
+      return charset.latinHebrew.encoder;
+    case 'latin-5':
+      return charset.latin5.encoder;
+    case 'latin-6':
+      return charset.latin6.encoder;
+    case 'tis620':
+      return charset.latinThai.encoder;
+    case 'latin-7':
+      return charset.latin7.encoder;
+    case 'latin-8':
+      return charset.latin8.encoder;
+    case 'latin-9':
+      return charset.latin9.encoder;
+    case 'latin-10':
+      return charset.latin10.encoder;
+
+    case 'windows874':
+      return charset.windows874.encoder;
+    case 'windows1250':
+      return charset.windows1250.encoder;
+    case 'windows1251':
+      return charset.windows1251.encoder;
+    case 'windows1252':
+    case 'latin-1':
+      return charset.windows1252.encoder;
+    case 'windows1253':
+      return charset.windows1253.encoder;
+    case 'windows1254':
+      return charset.windows1254.encoder;
+    case 'windows1255':
+      return charset.windows1255.encoder;
+    case 'windows1256':
+      return charset.windows1256.encoder;
+    case 'windows1257':
+      return charset.windows1257.encoder;
+    case 'windows1258':
+      return charset.windows1258.encoder;
+
+    case 'cp437':
+      return charset.cp437.encoder;
+    case 'cp737':
+      return charset.cp737.encoder;
+    case 'cp775':
+      return charset.cp775.encoder;
+    case 'cp850':
+      return charset.cp850.encoder;
+    case 'cp852':
+      return charset.cp852.encoder;
+    case 'cp855':
+      return charset.cp855.encoder;
+    case 'cp856':
+      return charset.cp856.encoder;
+    case 'cp857':
+      return charset.cp857.encoder;
+    case 'cp858':
+      return charset.cp858.encoder;
+    case 'cp860':
+      return charset.cp860.encoder;
+    case 'cp861':
+      return charset.cp861.encoder;
+    case 'cp862':
+      return charset.cp862.encoder;
+    case 'cp863':
+      return charset.cp863.encoder;
+    case 'cp864':
+      return charset.cp864.encoder;
+    case 'cp865':
+      return charset.cp865.encoder;
+    case 'cp866':
+      return charset.cp866.encoder;
+    case 'cp869':
+      return charset.cp869.encoder;
+    case 'cp922':
+      return charset.cp922.encoder;
+    case 'cp1046':
+      return charset.cp1046.encoder;
+    case 'cp1124':
+      return charset.cp1124.encoder;
+    case 'cp1125':
+      return charset.cp1125.encoder;
+    case 'cp1129':
+      return charset.cp1129.encoder;
+    case 'cp1133':
+      return charset.cp1133.encoder;
+    case 'cp1161':
+      return charset.cp1161.encoder;
+    case 'cp1162':
+      return charset.cp1162.encoder;
+    case 'cp1163':
+      return charset.cp1163.encoder;
+
+    default:
+      return null;
+  }
+}
+
+/// Encodes the `String` [s] into bytes.
+///
+/// If an explicit [encoder] is provided, it is used first.
+/// Otherwise, if [charset] is provided, a matching encoder is resolved
+/// via `getCharsetEncoder(charset)`.
+///
+/// If encoding with the resolved encoder fails or no encoder is available,
+/// the function falls back to [latin1]. If [latin1] encoding also fails,
+/// it finally falls back to [utf8].
+Uint8List encodeChars(String s, {CharsetEncoder? encoder, String? charset}) {
+  encoder ??= getCharsetEncoder(charset);
+
+  try {
+    if (encoder != null) {
+      var bs = encoder.convert(s);
+      return bs is Uint8List ? bs : Uint8List.fromList(bs);
+    }
+  } catch (_) {}
+
   try {
     return latin1.encode(s);
   } catch (_) {

--- a/lib/src/utils/generator.dart
+++ b/lib/src/utils/generator.dart
@@ -130,7 +130,9 @@ abstract class Generator {
     if (isKanji) {
       return Uint8List.fromList(gbk_bytes.encode(text));
     } else {
-      return encodeChars(text);
+      var charset = selectedCharset;
+      var encoder = selectedCharsetEncoder;
+      return encodeChars(text, encoder: encoder, charset: charset);
     }
   }
 
@@ -183,6 +185,21 @@ abstract class Generator {
 
   /// Clear the buffer and reset text styles.
   List<int> reset();
+
+  /// Selects the character code table. Default table: 0 PC437 (USA, standard)
+  List<int> selectCharCodeTable({int codeTable = 0});
+
+  /// Currently selected character code table (`n` value of `ESC t n`),
+  /// or `null` if no table has been selected yet.
+  int? get selectedCharCodeTable;
+
+  /// Charset name associated with the currently selected character code table,
+  /// or `null` if the table has no explicit charset mapping.
+  String? get selectedCharset;
+
+  /// Charset encoder corresponding to [selectedCharset],
+  /// or `null` if no charset is associated or no encoder is available.
+  CharsetEncoder? get selectedCharsetEncoder;
 
   /// Ends printer job.
   List<int> endJob();

--- a/lib/src/utils/generator_esc_pos.dart
+++ b/lib/src/utils/generator_esc_pos.dart
@@ -8,6 +8,7 @@
 
 import 'dart:typed_data' show Uint8List;
 
+import 'package:collection/collection.dart';
 import 'package:hex/hex.dart';
 import 'package:image/image.dart';
 
@@ -162,12 +163,48 @@ class GeneratorEscPos extends Generator {
 
   @override
   List<int> reset() {
+    _clearSelectedCharCodeTable();
+
     globalStyles = const PosStyles();
     var bytes = cInit.codeUnits;
     bytes += setGlobalCodeTable(codeTable);
     bytes += setFont(globalFont);
     bytes += setStyles(initialStyle);
     globalStyles = initialStyle;
+    return bytes;
+  }
+
+  int? _selectedCharCodeTable;
+
+  @override
+  int? get selectedCharCodeTable => _selectedCharCodeTable;
+
+  String? _selectedCharset;
+
+  @override
+  String? get selectedCharset => _selectedCharset;
+
+  CharsetEncoder? _selectedCharsetEncoder;
+
+  @override
+  CharsetEncoder? get selectedCharsetEncoder => _selectedCharsetEncoder;
+
+  void _clearSelectedCharCodeTable() {
+    _selectedCharCodeTable = null;
+    _selectedCharset = null;
+    _selectedCharsetEncoder = null;
+  }
+
+  @override
+  List<int> selectCharCodeTable({int codeTable = 0}) {
+    _selectedCharCodeTable = codeTable;
+
+    var charCodeTableEscPos = CharCodeTableEscPos.fromCode(codeTable);
+    _selectedCharset = charCodeTableEscPos?.charset;
+    _selectedCharsetEncoder = charCodeTableEscPos?.encoder;
+
+    var bytes = cCodeTable.codeUnits;
+    bytes += [codeTable & 0xFF];
     return bytes;
   }
 
@@ -808,4 +845,96 @@ class GeneratorEscPos extends Generator {
     return bytes;
   }
 // ************************ (end) Internal command generators ************************
+}
+
+/// ESC/POS character code tables.
+///
+/// Used with the ESC/POS command:
+///   ESC t n
+///
+/// Notes:
+/// - Support varies by printer model and firmware.
+/// - After `ESC @`, the printer reverts to its factory default table
+///   (commonly PC437 or PC850).
+/// - Text must be encoded according to the selected table before printing.
+enum CharCodeTableEscPos {
+  /// PC437 — USA (default on many printers)
+  pc437(0, 'cp437'),
+
+  /// PC850 — Multilingual (Western Europe, OEM)
+  pc850(2, 'cp850'),
+
+  /// PC860 — Portuguese
+  pc860(3, 'cp860'),
+
+  /// PC863 — Canadian French
+  pc863(4, 'cp863'),
+
+  /// PC865 — Nordic
+  pc865(5, 'cp865'),
+
+  /// Windows-1252 — Western Europe (Latin-1 superset)
+  wpc1252(16, 'windows1252'),
+
+  /// LATIN-1: Alias to Windows-1252 — Western Europe (Latin-1 superset)
+  latin1(16, 'windows1252'),
+
+  /// PC866 — Cyrillic
+  pc866(17, 'cp866'),
+
+  /// PC852 — Central Europe
+  pc852(18, 'cp852'),
+
+  /// PC858 — Multilingual with Euro sign
+  pc858(19, 'cp858'),
+
+  /// PC864 — Arabic
+  pc864(20, 'cp864'),
+
+  /// PC737 — Greek
+  pc737(21, 'cp737'),
+
+  /// PC857 — Turkish
+  pc857(22, 'cp857'),
+
+  /// PC862 — Hebrew
+  pc862(23, 'cp862'),
+
+  /// PC874 — Thai
+  pc874(24, 'windows874'),
+
+  /// Windows-1250 — Central Europe
+  wpc1250(25, 'windows1250'),
+
+  /// Windows-1251 — Cyrillic
+  wpc1251(26, 'windows1251'),
+
+  /// Windows-1253 — Greek
+  wpc1253(27, 'windows1253'),
+
+  /// Windows-1254 — Turkish
+  wpc1254(28, 'windows1254'),
+
+  /// Windows-1255 — Hebrew
+  wpc1255(29, 'windows1255'),
+
+  /// Windows-1256 — Arabic
+  wpc1256(30, 'windows1256'),
+
+  /// Windows-1257 — Baltic
+  wpc1257(31, 'windows1257'),
+
+  /// Windows-1258 — Vietnamese
+  wpc1258(32, 'windows1258');
+
+  /// Numeric value used by the `ESC t n` command.
+  final int code;
+  final String? charset;
+
+  const CharCodeTableEscPos(this.code, [this.charset]);
+
+  static CharCodeTableEscPos? fromCode(int code) =>
+      CharCodeTableEscPos.values.firstWhereOrNull((e) => e.code == code);
+
+  CharsetEncoder? get encoder => getCharsetEncoder(charset);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: esc_pos_dart
 description: ESC/POS thermal WiFi printer support for Dart (non-Flutter dependent).
-version: 1.2.0
+version: 1.2.1
 repository: https://github.com/gmpassos/esc_pos_dart
 
 environment:
@@ -9,13 +9,14 @@ environment:
 dependencies:
   hex: ^0.2.0
   gbk_codec: ^0.4.0
-  image: ^4.5.4
+  image: ^4.7.2
   resource_portable: ^3.1.2
-  collection: ^1.19.0
+  collection: ^1.19.1
+  charset: ^2.0.1
 
 dev_dependencies:
   lints: ^5.1.1
-  test: ^1.26.2
-  dependency_validator: ^5.0.2
-  coverage: ^1.14.1
+  test: ^1.29.0
+  dependency_validator: ^5.0.3
+  coverage: ^1.15.0
   intl: ^0.20.2


### PR DESCRIPTION
- `PrinterDocument`:
  - `print`: added optional parameter `selectCharCodeTable` to select character code table before printing.

- `GenericPrinter`:
  - Added method `selectCharCodeTable({int codeTable = 0})` to send ESC/POS command to select character code table.

- `Generator` (abstract):
  - Added methods and properties for character code table support:
    - `selectCharCodeTable({int codeTable = 0})`
    - `int? get selectedCharCodeTable`
    - `String? get selectedCharset`
    - `CharsetEncoder? get selectedCharsetEncoder`

- `GeneratorEscPos`:
  - Implemented character code table selection and tracking:
    - `_selectedCharCodeTable`, `_selectedCharset`, `_selectedCharsetEncoder` fields.
    - `selectCharCodeTable` updates selected table and charset encoder.
    - `reset` clears selected character code table.
  - Added enum `CharCodeTableEscPos` mapping ESC/POS code tables to charset names and encoders.
  - Updated text encoding to use selected charset encoder if available.

- `char_encoder.dart`:
  - Added comprehensive charset encoder resolution via `getCharsetEncoder(String? name)` using `charset` package.
  - Updated `encodeChars` to accept optional `CharsetEncoder` or charset name and fallback to latin1 or utf8 if encoding fails.

- Dependency updates:
  - Added `charset: ^2.0.1`
  - Updated `image` to ^4.7.2
  - Updated `collection` to ^1.19.1
  - Updated `test` to ^1.29.0
  - Updated `dependency_validator` to ^5.0.3
  - Updated `coverage` to ^1.15.0