### PR TITLE
v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-## 1.2.2
+## 1.3.0
 
 - `PrinterDocument`:
   - Added `fontSize` field with clamped range 1 to 8.
   - Updated constructor to accept optional `fontSize` parameter.
+    - **Breaking change:** The constructor now uses named parameters.
   - Updated `fromJson` and `toJson` to handle `fontSize`.
 
 - `Generator`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 1.2.2
+
+- `PrinterDocument`:
+  - Added `fontSize` field with clamped range 1 to 8.
+  - Updated constructor to accept optional `fontSize` parameter.
+  - Updated `fromJson` and `toJson` to handle `fontSize`.
+
+- `Generator`:
+  - Updated `getCharsPerLine` to adjust character count based on `PosStyles.width` scaling.
+
+- Dependencies:
+  - Updated `image` to ^4.8.0.
+  - Updated `test` to ^1.30.0.
+  - Updated `dependency_validator` to ^5.0.4.
+
 ## 1.2.1
 
 - `PrinterDocument`:

--- a/lib/src/esc_pos_base.dart
+++ b/lib/src/esc_pos_base.dart
@@ -13,12 +13,19 @@ import 'utils/pos_styles.dart';
 /// An ESC/POS printer document.
 /// See [NetworkPrinter].
 class PrinterDocument {
+  final int fontSize;
+
   final List<PrinterCommand> commands;
 
-  PrinterDocument([List<PrinterCommand>? commands]) : commands = commands ?? [];
+  PrinterDocument({List<PrinterCommand>? commands, int fontSize = 1})
+      : commands = commands ?? [],
+        fontSize = fontSize.clamp(1, 8).toInt();
 
   factory PrinterDocument.fromJson(Map<String, dynamic> j) => PrinterDocument(
-        (j['commands'] as List).map((e) => PrinterCommand.fromJson(e)).toList(),
+        commands: (j['commands'] as List)
+            .map((e) => PrinterCommand.fromJson(e))
+            .toList(),
+        fontSize: j['fontSize'] ?? 1,
       );
 
   PrinterCommand addCommand(PrinterCommand command) {
@@ -80,6 +87,7 @@ class PrinterDocument {
   }
 
   Map<String, dynamic> toJson() => {
+        'fontSize': fontSize,
         'commands': commands.map((e) => e.toJson()).toList(),
       };
 

--- a/lib/src/utils/generator.dart
+++ b/lib/src/utils/generator.dart
@@ -178,6 +178,13 @@ abstract class Generator {
   int getCharsPerLine(PosStyles styles, int? maxCharsPerLine) {
     var fontType = styles.fontType ?? globalFont;
     var charsPerLine = maxCharsPerLine ?? getMaxCharsPerLine(fontType);
+    var fontWidth = styles.width;
+
+    var fontWidthScale = fontWidth.value;
+    if (fontWidthScale > 1) {
+      charsPerLine = charsPerLine ~/ fontWidthScale;
+    }
+
     return charsPerLine;
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: esc_pos_dart
 description: ESC/POS thermal WiFi printer support for Dart (non-Flutter dependent).
-version: 1.2.1
+version: 1.2.2
 repository: https://github.com/gmpassos/esc_pos_dart
 
 environment:
@@ -9,14 +9,14 @@ environment:
 dependencies:
   hex: ^0.2.0
   gbk_codec: ^0.4.0
-  image: ^4.7.2
+  image: ^4.8.0
   resource_portable: ^3.1.2
   collection: ^1.19.1
   charset: ^2.0.1
 
 dev_dependencies:
   lints: ^5.1.1
-  test: ^1.29.0
-  dependency_validator: ^5.0.3
+  test: ^1.30.0
+  dependency_validator: ^5.0.4
   coverage: ^1.15.0
   intl: ^0.20.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: esc_pos_dart
 description: ESC/POS thermal WiFi printer support for Dart (non-Flutter dependent).
-version: 1.2.2
+version: 1.3.0
 repository: https://github.com/gmpassos/esc_pos_dart
 
 environment:

--- a/test/esc_pos_dart_test.dart
+++ b/test/esc_pos_dart_test.dart
@@ -14,6 +14,7 @@ void main() {
           json1,
           equals(
             {
+              'fontSize': 2,
               'commands': [
                 {'type': 'text', 'text': 'Hello'},
                 {
@@ -41,6 +42,9 @@ void main() {
           ));
 
       var doc2 = PrinterDocument.fromJson(json1);
+
+      expect(doc2.fontSize, equals(2));
+      expect(doc2.commands.length, equals(6));
 
       var json2 = doc2.toJson();
       expect(json2, equals(json1));
@@ -1707,7 +1711,7 @@ PrinterDocument _buildPrinterDocument1() {
   var image = Image(width: 1, height: 1, numChannels: 4);
   image.setPixel(0, 0, ColorRgba8(255, 0, 0, 255));
 
-  var doc = PrinterDocument();
+  var doc = PrinterDocument(fontSize: 2);
 
   doc.addText(text: 'Hello', style: PrinterCommandStyle(align: PosAlign.left));
 


### PR DESCRIPTION
- `PrinterDocument`:
  - Added `fontSize` field with clamped range 1 to 8.
  - Updated constructor to accept optional `fontSize` parameter.
  - Updated `fromJson` and `toJson` to handle `fontSize`.

- `Generator`:
  - Updated `getCharsPerLine` to adjust character count based on `PosStyles.width` scaling.

- Dependencies:
  - Updated `image` to ^4.8.0.
  - Updated `test` to ^1.30.0.
  - Updated `dependency_validator` to ^5.0.4.