### PR TITLE
v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,47 @@
+## 1.3.2
+
+- `PrinterDocument`:
+  - `print`: added optional `selectCharCodeTable` parameter.
+  - `print`: pass initial `PosStyles` with font size to `printer.reset()`.
+  - `print`: ensure `fontSize` style is applied via `printer.setStyles()`.
+
+- `PrinterCommandStyle`:
+  - Changed all fields to nullable.
+  - Added `const` constructor and `defaults` constructor.
+  - `fromJson`: no longer provide default values; fields nullable.
+  - `toJson`: serialize only non-null fields.
+  - `toPosStyles`: treat null booleans as false; convert nullable width/height to `PosTextSize` or null.
+  - Removed internal `getPosTextSize` method.
+
+- `GenericPrinter`:
+  - `reset` method now accepts optional `PosStyles` parameter and passes it to generator.
+
+- `DecoderEscPos`:
+  - Added support for GS command 0x21 to decode font size.
+  - Added `CommandEscPosFontSize` command with width and height size parameters.
+  - Updated `CommandEscPos.fromJson` to support `font-size` command.
+
+- `enums.dart`:
+  - Added `PosTextSize.encodeSize` to encode width and height into a single int.
+  - Added `PosTextSize.decodeSize` to decode int into width and height `PosTextSize` values.
+
+- `Generator`:
+  - `reset` now accepts optional `PosStyles` parameter.
+  - Added `setAlign` method with optional `force` parameter.
+  - Updated `setGlobalCodeTable` and `setFont` to accept `force` parameter.
+  - Updated `setStyles` to handle nullable width and height, and encode font size using `PosTextSize.encodeSize`.
+  - Updated `getCharWidth` and `getCharsPerLine` to handle nullable width and global styles fallback.
+
+- `GeneratorEscPos`:
+  - Implemented `reset` with optional `styles` parameter, applying initial styles with defaults.
+  - Implemented `setAlign` to update alignment if changed or forced.
+  - Updated `setStyles` to handle nullable height and width, and encode font size accordingly.
+
+- `PosStyles`:
+  - Made `height` and `width` nullable.
+  - Added `copyWithDefaults` method to fill null fields from defaults or parameters.
+  - Updated constructors to allow nullable height and width.
+
 ## 1.3.1
 
 - `PrinterDocument`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.3.2
+## 1.3.1
 
 - `PrinterDocument`:
   - `print`: added optional `selectCharCodeTable` parameter.
@@ -42,13 +42,6 @@
   - Added `copyWithDefaults` method to fill null fields from defaults or parameters.
   - Updated constructors to allow nullable height and width.
 
-## 1.3.1
-
-- `PrinterDocument`:
-  - Updated `print` method to apply text size styles using `PosTextSize.withValue` and `printer.setStyles` when `fontSize` is set.
-
-- `enums.dart`:
-  - Added import of `package:collection/collection.dart`.
   - `PosTextSize`:
     - Added static method `withValue(int value)` to return a `PosTextSize` enum matching the given value or null if none matches.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.3.1
+
+- `PrinterDocument`:
+  - Updated `print` method to apply text size styles using `PosTextSize.withValue` and `printer.setStyles` when `fontSize` is set.
+
+- `enums.dart`:
+  - Added import of `package:collection/collection.dart`.
+  - `PosTextSize`:
+    - Added static method `withValue(int value)` to return a `PosTextSize` enum matching the given value or null if none matches.
+
 ## 1.3.0
 
 - `PrinterDocument`:

--- a/lib/src/esc_pos_base.dart
+++ b/lib/src/esc_pos_base.dart
@@ -69,19 +69,20 @@ class PrinterDocument {
       {bool reset = true, int? selectCharCodeTable, bool endJob = true}) {
     if (commands.isEmpty) return;
 
+    final textSize = PosTextSize.withValue(fontSize);
+
     if (reset) {
-      printer.reset();
+      var stylesInitial = PosStyles(width: textSize, height: textSize);
+      printer.reset(styles: stylesInitial);
     }
 
     if (selectCharCodeTable != null) {
       printer.selectCharCodeTable(codeTable: selectCharCodeTable);
     }
 
-    var textSize = PosTextSize.withValue(fontSize);
+    // Ensure `fontSize`:
     if (textSize != null) {
-      printer.setStyles(
-        PosStyles(width: textSize, height: textSize),
-      );
+      printer.setStyles(PosStyles(width: textSize, height: textSize));
     }
 
     for (var c in commands) {
@@ -158,88 +159,77 @@ PrinterCommandType? parsePrinterCommandType(Object? o) {
 }
 
 class PrinterCommandStyle {
-  final bool bold;
-  final bool reverse;
-  final bool underline;
-  final bool turn90;
-  final PosAlign align;
-  final int width;
-  final int height;
-  final PosFontType fontType;
-  final String codeTable;
+  final bool? bold;
+  final bool? reverse;
+  final bool? underline;
+  final bool? turn90;
+  final PosAlign? align;
+  final int? width;
+  final int? height;
+  final PosFontType? fontType;
+  final String? codeTable;
 
-  PrinterCommandStyle(
-      {this.bold = false,
-      this.reverse = false,
-      this.underline = false,
-      this.turn90 = false,
-      this.align = PosAlign.left,
-      this.width = 1,
-      this.height = 1,
-      this.fontType = PosFontType.fontA,
-      this.codeTable = 'CP437'});
+  const PrinterCommandStyle(
+      {this.bold,
+      this.reverse,
+      this.underline,
+      this.turn90,
+      this.align,
+      this.width,
+      this.height,
+      this.fontType,
+      this.codeTable});
+
+  const PrinterCommandStyle.defaults({
+    this.bold = false,
+    this.reverse = false,
+    this.underline = false,
+    this.turn90 = false,
+    this.align = PosAlign.left,
+    this.width = 1,
+    this.height = 1,
+    this.fontType = PosFontType.fontA,
+    this.codeTable = 'CP437',
+  });
 
   factory PrinterCommandStyle.fromJson(Map<String, dynamic> j) =>
       PrinterCommandStyle(
-        bold: j['bold'] as bool? ?? false,
-        reverse: j['reverse'] as bool? ?? false,
-        underline: j['underline'] as bool? ?? false,
-        turn90: j['turn90'] as bool? ?? false,
-        align: PosAlign.from(j['align']) ?? PosAlign.left,
-        width: j['width'] as int? ?? 1,
-        height: j['height'] as int? ?? 1,
-        fontType: PosFontType.from(j['fontType']) ?? PosFontType.fontA,
-        codeTable: j['codeTable'] as String? ?? 'CP437',
+        bold: j['bold'] as bool?,
+        reverse: j['reverse'] as bool?,
+        underline: j['underline'] as bool?,
+        turn90: j['turn90'] as bool?,
+        align: PosAlign.from(j['align']),
+        width: j['width'] as int?,
+        height: j['height'] as int?,
+        fontType: PosFontType.from(j['fontType']),
+        codeTable: j['codeTable'] as String?,
       );
 
   bool get isDefault => toJson().isEmpty;
 
   Map<String, dynamic> toJson() => {
-        if (bold) 'bold': bold,
-        if (reverse) 'reverse': reverse,
-        if (underline) 'underline': underline,
-        if (turn90) 'turn90': turn90,
-        if (align != PosAlign.left) 'align': align.name,
-        if (width != 1) 'width': width,
-        if (height != 1) 'height': height,
-        if (fontType != PosFontType.fontA) 'fontType': fontType.valueName,
-        if (codeTable != 'CP437') 'codeTable': codeTable,
+        if (bold != null) 'bold': bold,
+        if (reverse != null) 'reverse': reverse,
+        if (underline != null) 'underline': underline,
+        if (turn90 != null) 'turn90': turn90,
+        if (align != null) 'align': align!.name,
+        if (width != null) 'width': width,
+        if (height != null) 'height': height,
+        if (fontType != null) 'fontType': fontType!.valueName,
+        if (codeTable != null) 'codeTable': codeTable,
       };
 
   PosStyles toPosStyles() => PosStyles(
-        bold: bold,
-        reverse: reverse,
-        underline: underline,
-        turn90: turn90,
+        bold: bold ?? false,
+        reverse: reverse ?? false,
+        underline: underline ?? false,
+        turn90: turn90 ?? false,
         align: align,
-        width: getPosTextSize(width),
-        height: getPosTextSize(height),
+        width: width != null ? PosTextSize.withValue(width!) : null,
+        height: height != null ? PosTextSize.withValue(height!) : null,
         fontType: fontType,
         codeTable: codeTable,
       );
-
-  static PosTextSize getPosTextSize(int size) {
-    switch (size) {
-      case 1:
-        return PosTextSize.size1;
-      case 2:
-        return PosTextSize.size2;
-      case 3:
-        return PosTextSize.size3;
-      case 4:
-        return PosTextSize.size4;
-      case 5:
-        return PosTextSize.size5;
-      case 6:
-        return PosTextSize.size6;
-      case 7:
-        return PosTextSize.size7;
-      case 8:
-        return PosTextSize.size8;
-      default:
-        throw UnsupportedError("Unsupported size: $size");
-    }
-  }
 }
 
 abstract class PrinterCommand {

--- a/lib/src/esc_pos_base.dart
+++ b/lib/src/esc_pos_base.dart
@@ -77,6 +77,13 @@ class PrinterDocument {
       printer.selectCharCodeTable(codeTable: selectCharCodeTable);
     }
 
+    var textSize = PosTextSize.withValue(fontSize);
+    if (textSize != null) {
+      printer.setStyles(
+        PosStyles(width: textSize, height: textSize),
+      );
+    }
+
     for (var c in commands) {
       c.print(printer);
     }

--- a/lib/src/printer/generic_printer.dart
+++ b/lib/src/printer/generic_printer.dart
@@ -42,8 +42,8 @@ abstract class GenericPrinter {
   void writeBytes(List<int> bytes);
 
   // ************************ Printer Commands ************************
-  void reset() {
-    writeBytes(_generator.reset());
+  void reset({PosStyles? styles}) {
+    writeBytes(_generator.reset(styles: styles));
   }
 
   void selectCharCodeTable({int codeTable = 0}) {

--- a/lib/src/utils/decoder_esc_pos.dart
+++ b/lib/src/utils/decoder_esc_pos.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:collection/collection.dart';
 
 import 'decoder.dart';
+import 'enums.dart';
 
 /// Decodes ESC/POS commands from received print data,
 /// extracting text, formatting, and control instructions.
@@ -22,6 +23,7 @@ class DecoderEscPos extends Decoder {
 
   static const _gs = 0x1D;
   static const _gsCut = 0x56;
+  static const _gsFontSize = 0x21;
 
   static const _endJob = 0x0C;
 
@@ -235,6 +237,18 @@ class DecoderEscPos extends Decoder {
                                     "Invalid cut parameter: $c2"))),
                   );
                 }
+              case _gsFontSize:
+                {
+                  var c2 = serial[(offset + consumed)];
+                  ++consumed;
+
+                  var sz = PosTextSize.decodeSize(c2);
+
+                  _output.add(CommandEscPosFontSize(
+                    widthSize: sz.width.value,
+                    heightSize: sz.height.value,
+                  ));
+                }
               default:
                 throw FormatException("Unknown GS char: $c1");
             }
@@ -288,6 +302,8 @@ abstract class CommandEscPos extends Command {
         return CommandEscPosTable.fromJson(json);
       case 'font':
         return CommandEscPosFont.fromJson(json);
+      case 'font-size':
+        return CommandEscPosFontSize.fromJson(json);
       case 'align':
         return CommandEscPosAlign.fromJson(json);
       case 'bold':
@@ -377,6 +393,26 @@ class CommandEscPosFont extends CommandEscPos {
     var parameters = json["parameters"] as List?;
     var p = parameters?[0] as String?;
     return CommandEscPosFont(a: p == 'a', b: p == 'b');
+  }
+}
+
+class CommandEscPosFontSize extends CommandEscPos {
+  final int widthSize;
+  final int heightSize;
+
+  CommandEscPosFontSize({int? widthSize, int? heightSize})
+      : widthSize = (widthSize ?? 1).clamp(1, 8),
+        heightSize = (heightSize ?? 1).clamp(1, 8),
+        super('font-size');
+
+  @override
+  List get parameters => [widthSize, heightSize];
+
+  factory CommandEscPosFontSize.fromJson(Map json) {
+    var parameters = json["parameters"] as List?;
+    var w = parameters?[0] as int?;
+    var h = parameters?[1] as int?;
+    return CommandEscPosFontSize(widthSize: w, heightSize: h);
   }
 }
 

--- a/lib/src/utils/enums.dart
+++ b/lib/src/utils/enums.dart
@@ -6,6 +6,8 @@
  * See LICENSE for distribution and usage details.
  */
 
+import 'package:collection/collection.dart';
+
 enum PosAlign {
   left(0),
   center(1),
@@ -91,6 +93,9 @@ enum PosTextSize {
 
   static int decSize(PosTextSize height, PosTextSize width) =>
       16 * (width.value - 1) + (height.value - 1);
+
+  static PosTextSize? withValue(int value) =>
+      PosTextSize.values.firstWhereOrNull((e) => e.value == value);
 }
 
 enum PaperSize {

--- a/lib/src/utils/enums.dart
+++ b/lib/src/utils/enums.dart
@@ -91,8 +91,23 @@ enum PosTextSize {
 
   const PosTextSize(this.value);
 
-  static int decSize(PosTextSize height, PosTextSize width) =>
+  static int encodeSize(PosTextSize height, PosTextSize width) =>
       16 * (width.value - 1) + (height.value - 1);
+
+  static ({PosTextSize width, PosTextSize height}) decodeSize(int n) {
+    var width = n ~/ 16 + 1;
+    var height = n % 16 + 1;
+
+    var posTextSizeW = PosTextSize.withValue(width) ??
+        (throw StateError(
+            "Can't find `width` `PosTextSize` for value: $width"));
+
+    var posTextSizeH = PosTextSize.withValue(height) ??
+        (throw StateError(
+            "Can't find `height` `PosTextSize` for value: $height"));
+
+    return (width: posTextSizeW, height: posTextSizeH);
+  }
 
   static PosTextSize? withValue(int value) =>
       PosTextSize.values.firstWhereOrNull((e) => e.value == value);

--- a/lib/src/utils/generator.dart
+++ b/lib/src/utils/generator.dart
@@ -170,7 +170,8 @@ abstract class Generator {
   /// charWidth = default width * text size multiplier
   double getCharWidth(PosStyles styles, {int? maxCharsPerLine}) {
     var charsPerLine = getCharsPerLine(styles, maxCharsPerLine);
-    var charWidth = (paperSize.width / charsPerLine) * styles.width.value;
+    var width = styles.width ?? globalStyles.width ?? PosTextSize.size1;
+    var charWidth = (paperSize.width / charsPerLine) * width.value;
     return charWidth;
   }
 
@@ -178,7 +179,8 @@ abstract class Generator {
   int getCharsPerLine(PosStyles styles, int? maxCharsPerLine) {
     var fontType = styles.fontType ?? globalFont;
     var charsPerLine = maxCharsPerLine ?? getMaxCharsPerLine(fontType);
-    var fontWidth = styles.width;
+
+    var fontWidth = styles.width ?? globalStyles.width ?? PosTextSize.size1;
 
     var fontWidthScale = fontWidth.value;
     if (fontWidthScale > 1) {
@@ -191,7 +193,9 @@ abstract class Generator {
   //**************************** Public command generators ************************
 
   /// Clear the buffer and reset text styles.
-  List<int> reset();
+  ///
+  /// - [styles] is the initial/reset styles to use for printing.
+  List<int> reset({PosStyles? styles});
 
   /// Selects the character code table. Default table: 0 PC437 (USA, standard)
   List<int> selectCharCodeTable({int codeTable = 0});
@@ -215,11 +219,15 @@ abstract class Generator {
   /// (even after resetting)
   List<int> setGlobalCodeTable(String? codeTable);
 
-  /// Set global font which will be used instead of the default printer's font
-  /// (even after resetting)
+  /// Set global font which will be used.
+  /// See [initialStyle] and [setStyles].
   List<int> setFont(PosFontType font, {int? maxCharsPerLine});
 
   int getMaxCharsPerLine(PosFontType font);
+
+  /// Set global align which will be used.
+  /// See [initialStyle] and [setStyles].
+  List<int> setAlign(PosAlign align, {bool force = false});
 
   /// Temporarily applies [styles], executes [block], and then restores the previous styles.
   ///

--- a/lib/src/utils/generator_esc_pos.dart
+++ b/lib/src/utils/generator_esc_pos.dart
@@ -162,15 +162,39 @@ class GeneratorEscPos extends Generator {
   //**************************** Public command generators ************************
 
   @override
-  List<int> reset() {
+  List<int> reset({PosStyles? styles}) {
     _clearSelectedCharCodeTable();
 
-    globalStyles = const PosStyles();
+    var stylesInitial = initialStyle
+        .copyWithDefaults(
+          codeTable: codeTable,
+          fontType: globalFont,
+        )
+        .copyWithDefaults(
+          stylesDefaults: const PosStyles.defaults(),
+        );
+
+    // If `styles` is passed, use it as initial styles:
+    if (styles != null) {
+      stylesInitial = styles.copyWithDefaults(stylesDefaults: stylesInitial);
+    }
+
+    // Reset printer and set `globalStyles` as reset (defaults)
     var bytes = cInit.codeUnits;
-    bytes += setGlobalCodeTable(codeTable);
-    bytes += setFont(globalFont);
-    bytes += setStyles(initialStyle);
-    globalStyles = initialStyle;
+    globalStyles = const PosStyles.defaults();
+
+    // Ensure code table set:
+    bytes +=
+        setGlobalCodeTable(stylesInitial.codeTable ?? codeTable, force: true);
+    // Ensure font set:
+    bytes += setFont(stylesInitial.fontType ?? globalFont, force: true);
+
+    // Ensure font set:
+    bytes += setAlign(stylesInitial.align ?? PosAlign.left, force: true);
+
+    // Set the initial styles:
+    bytes += setStyles(stylesInitial);
+
     return bytes;
   }
 
@@ -215,9 +239,9 @@ class GeneratorEscPos extends Generator {
   }
 
   @override
-  List<int> setGlobalCodeTable(String? codeTable) {
+  List<int> setGlobalCodeTable(String? codeTable, {bool force = false}) {
     List<int> bytes;
-    if (codeTable != null && globalStyles.codeTable != codeTable) {
+    if (codeTable != null && (force || globalStyles.codeTable != codeTable)) {
       globalStyles = globalStyles.copyWith(codeTable: codeTable);
       bytes = <int>[
         ...cCodeTable.codeUnits,
@@ -230,9 +254,10 @@ class GeneratorEscPos extends Generator {
   }
 
   @override
-  List<int> setFont(PosFontType font, {int? maxCharsPerLine}) {
+  List<int> setFont(PosFontType font,
+      {int? maxCharsPerLine, bool force = false}) {
     List<int> bytes;
-    if (globalStyles.fontType != font) {
+    if (force || globalStyles.fontType != font) {
       globalStyles = globalStyles.copyWith(fontType: font);
       globalMaxCharsPerLine = maxCharsPerLine ?? getMaxCharsPerLine(font);
       bytes = font == PosFontType.fontB ? cFontB.codeUnits : cFontA.codeUnits;
@@ -255,6 +280,20 @@ class GeneratorEscPos extends Generator {
             ? (48 - 6)
             : (64 - 8);
     }
+  }
+
+  @override
+  List<int> setAlign(PosAlign align, {bool force = false}) {
+    var bytes = <int>[];
+
+    if (force || align != globalStyles.align) {
+      bytes += encodeChars(align == PosAlign.left
+          ? cAlignLeft
+          : (align == PosAlign.center ? cAlignCenter : cAlignRight));
+      globalStyles = globalStyles.copyWith(align: align);
+    }
+
+    return bytes;
   }
 
   @override
@@ -311,13 +350,17 @@ class GeneratorEscPos extends Generator {
     }
 
     // Characters size
-    final height = styles.height;
-    final width = styles.width;
-    if (height.value != globalStyles.height.value ||
-        width.value != globalStyles.width.value) {
+    var height = styles.height;
+    var width = styles.width;
+
+    if ((height != null && height.value != globalStyles.height?.value) ||
+        (width != null && width.value != globalStyles.width?.value)) {
+      height ??= globalStyles.height ?? PosTextSize.size1;
+      width ??= globalStyles.width ?? PosTextSize.size1;
+
       bytes += [
         ...cSizeGSn.codeUnits,
-        PosTextSize.decSize(height, width),
+        PosTextSize.encodeSize(height, width),
       ];
       globalStyles = globalStyles.copyWith(height: height, width: width);
     }

--- a/lib/src/utils/pos_styles.dart
+++ b/lib/src/utils/pos_styles.dart
@@ -16,8 +16,8 @@ class PosStyles {
     this.underline = false,
     this.turn90 = false,
     this.align,
-    this.height = PosTextSize.size1,
-    this.width = PosTextSize.size1,
+    this.height,
+    this.width,
     this.fontType,
     this.codeTable,
     this.isKanji = false,
@@ -42,8 +42,8 @@ class PosStyles {
   final bool underline;
   final bool turn90;
   final PosAlign? align;
-  final PosTextSize height;
-  final PosTextSize width;
+  final PosTextSize? height;
+  final PosTextSize? width;
   final PosFontType? fontType;
   final String? codeTable;
   final bool isKanji;
@@ -71,6 +71,27 @@ class PosStyles {
       fontType: fontType ?? this.fontType,
       codeTable: codeTable ?? this.codeTable,
       isKanji: isKanji ?? this.isKanji,
+    );
+  }
+
+  PosStyles copyWithDefaults(
+      {PosAlign? align,
+      PosTextSize? height,
+      PosTextSize? width,
+      PosFontType? fontType,
+      String? codeTable,
+      PosStyles? stylesDefaults}) {
+    return PosStyles(
+      bold: bold,
+      reverse: reverse,
+      underline: underline,
+      turn90: turn90,
+      align: this.align ?? align ?? stylesDefaults?.align,
+      height: this.height ?? height ?? stylesDefaults?.height,
+      width: this.width ?? width ?? stylesDefaults?.width,
+      fontType: this.fontType ?? fontType ?? stylesDefaults?.fontType,
+      codeTable: this.codeTable ?? codeTable ?? stylesDefaults?.codeTable,
+      isKanji: isKanji,
     );
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: esc_pos_dart
 description: ESC/POS thermal WiFi printer support for Dart (non-Flutter dependent).
-version: 1.3.0
+version: 1.3.1
 repository: https://github.com/gmpassos/esc_pos_dart
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: esc_pos_dart
 description: ESC/POS thermal WiFi printer support for Dart (non-Flutter dependent).
-version: 1.3.1
+version: 1.3.2
 repository: https://github.com/gmpassos/esc_pos_dart
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: esc_pos_dart
 description: ESC/POS thermal WiFi printer support for Dart (non-Flutter dependent).
-version: 1.3.2
+version: 1.3.1
 repository: https://github.com/gmpassos/esc_pos_dart
 
 environment:

--- a/test/esc_pos_dart_test.dart
+++ b/test/esc_pos_dart_test.dart
@@ -16,7 +16,11 @@ void main() {
             {
               'fontSize': 2,
               'commands': [
-                {'type': 'text', 'text': 'Hello'},
+                {
+                  'type': 'text',
+                  'text': 'Hello',
+                  'style': {'align': 'left'}
+                },
                 {
                   'type': 'text',
                   'text': 'World!',
@@ -286,6 +290,10 @@ void main() {
           'parameters': ['left']
         },
         {
+          'name': 'font-size',
+          'parameters': [2, 2]
+        },
+        {
           'name': 'text',
           'parameters': ['Hello\n']
         },
@@ -380,6 +388,9 @@ void main() {
             27,
             97,
             0,
+            29,
+            33,
+            17,
             72,
             101,
             108,


### PR DESCRIPTION
- `PrinterDocument`:
  - Updated `print` method to apply text size styles using `PosTextSize.withValue` and `printer.setStyles` when `fontSize` is set.

- `enums.dart`:
  - Added import of `package:collection/collection.dart`.
  - `PosTextSize`:
    - Added static method `withValue(int value)` to return a `PosTextSize` enum matching the given value or null if none matches.