### PR TITLE
v1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 1.3.2
+
+- `PrinterDocument`:
+  - Added `fontType` field with default `'a'`.
+  - Updated constructor to accept `fontType` parameter, normalizing to lowercase and trimming.
+  - Updated `fromJson` and `toJson` to include `fontType`.
+  - Updated `print` method to apply `fontType` along with `fontSize` in styles and printer commands.
+
+- `Generator`:
+  - Updated `getCharsPerLine` to accept named parameters and apply font width scaling conditionally.
+  - Updated `getCharWidth` to pass named parameter `maxCharsPerLine`.
+  - Updated `hr` method to calculate line length considering font width scaling.
+
 ## 1.3.1
 
 - `PrinterDocument`:

--- a/lib/src/esc_pos_base.dart
+++ b/lib/src/esc_pos_base.dart
@@ -13,18 +13,23 @@ import 'utils/pos_styles.dart';
 /// An ESC/POS printer document.
 /// See [NetworkPrinter].
 class PrinterDocument {
+  final String fontType;
   final int fontSize;
 
   final List<PrinterCommand> commands;
 
-  PrinterDocument({List<PrinterCommand>? commands, int fontSize = 1})
+  PrinterDocument(
+      {List<PrinterCommand>? commands, String fontType = 'a', int fontSize = 1})
       : commands = commands ?? [],
+        fontType =
+            fontType.trim().isNotEmpty ? fontType.trim().toLowerCase() : 'a',
         fontSize = fontSize.clamp(1, 8).toInt();
 
   factory PrinterDocument.fromJson(Map<String, dynamic> j) => PrinterDocument(
         commands: (j['commands'] as List)
             .map((e) => PrinterCommand.fromJson(e))
             .toList(),
+        fontType: j['fontType'] ?? 'a',
         fontSize: j['fontSize'] ?? 1,
       );
 
@@ -69,10 +74,12 @@ class PrinterDocument {
       {bool reset = true, int? selectCharCodeTable, bool endJob = true}) {
     if (commands.isEmpty) return;
 
+    var textFont = PosFontType.from(fontType);
     final textSize = PosTextSize.withValue(fontSize);
 
     if (reset) {
-      var stylesInitial = PosStyles(width: textSize, height: textSize);
+      var stylesInitial =
+          PosStyles(fontType: textFont, width: textSize, height: textSize);
       printer.reset(styles: stylesInitial);
     }
 
@@ -80,9 +87,10 @@ class PrinterDocument {
       printer.selectCharCodeTable(codeTable: selectCharCodeTable);
     }
 
-    // Ensure `fontSize`:
-    if (textSize != null) {
-      printer.setStyles(PosStyles(width: textSize, height: textSize));
+    // Ensure `fontType` and `fontSize`:
+    if (textFont != null || textSize != null) {
+      printer.setStyles(
+          PosStyles(fontType: textFont, width: textSize, height: textSize));
     }
 
     for (var c in commands) {
@@ -95,6 +103,7 @@ class PrinterDocument {
   }
 
   Map<String, dynamic> toJson() => {
+        'fontType': fontType,
         'fontSize': fontSize,
         'commands': commands.map((e) => e.toJson()).toList(),
       };

--- a/lib/src/utils/generator.dart
+++ b/lib/src/utils/generator.dart
@@ -169,22 +169,26 @@ abstract class Generator {
 
   /// charWidth = default width * text size multiplier
   double getCharWidth(PosStyles styles, {int? maxCharsPerLine}) {
-    var charsPerLine = getCharsPerLine(styles, maxCharsPerLine);
+    var charsPerLine =
+        getCharsPerLine(styles, maxCharsPerLine: maxCharsPerLine);
     var width = styles.width ?? globalStyles.width ?? PosTextSize.size1;
     var charWidth = (paperSize.width / charsPerLine) * width.value;
     return charWidth;
   }
 
   /// Calculates the average character width based on [styles] and [maxCharsPerLine].
-  int getCharsPerLine(PosStyles styles, int? maxCharsPerLine) {
+  int getCharsPerLine(PosStyles styles,
+      {int? maxCharsPerLine, bool applyWidth = false}) {
     var fontType = styles.fontType ?? globalFont;
     var charsPerLine = maxCharsPerLine ?? getMaxCharsPerLine(fontType);
 
-    var fontWidth = styles.width ?? globalStyles.width ?? PosTextSize.size1;
+    if (applyWidth) {
+      var fontWidth = styles.width ?? globalStyles.width ?? PosTextSize.size1;
 
-    var fontWidthScale = fontWidth.value;
-    if (fontWidthScale > 1) {
-      charsPerLine = charsPerLine ~/ fontWidthScale;
+      var fontWidthScale = fontWidth.value;
+      if (fontWidthScale > 1) {
+        charsPerLine = charsPerLine ~/ fontWidthScale;
+      }
     }
 
     return charsPerLine;
@@ -364,7 +368,15 @@ abstract class Generator {
       int linesAfter = 0,
       PosStyles styles = const PosStyles()}) {
     var font = styles.fontType ?? globalFont;
-    len ??= getMaxCharsPerLine(font);
+    var width = styles.width ?? globalStyles.width ?? PosTextSize.size1;
+
+    if (len == null) {
+      len = getMaxCharsPerLine(font);
+      if (width.value > 1) {
+        len = len ~/ width.value;
+      }
+    }
+
     var line = ch * len;
     return text(line, styles: styles);
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: esc_pos_dart
 description: ESC/POS thermal WiFi printer support for Dart (non-Flutter dependent).
-version: 1.3.1
+version: 1.3.2
 repository: https://github.com/gmpassos/esc_pos_dart
 
 environment:

--- a/test/esc_pos_dart_test.dart
+++ b/test/esc_pos_dart_test.dart
@@ -14,6 +14,7 @@ void main() {
           json1,
           equals(
             {
+              'fontType': 'a',
               'fontSize': 2,
               'commands': [
                 {
@@ -319,7 +320,7 @@ void main() {
         },
         {
           'name': 'text',
-          'parameters': ['------------------------------------------\n']
+          'parameters': ['---------------------\n']
         },
         {
           'name': 'align',
@@ -350,9 +351,7 @@ void main() {
         },
         {
           'name': 'text',
-          'parameters': [
-            '--------------------------------------------------------\n'
-          ]
+          'parameters': ['----------------------------\n']
         },
         {
           'name': 'font',
@@ -437,27 +436,6 @@ void main() {
             45,
             45,
             45,
-            45,
-            45,
-            45,
-            45,
-            45,
-            45,
-            45,
-            45,
-            45,
-            45,
-            45,
-            45,
-            45,
-            45,
-            45,
-            45,
-            45,
-            45,
-            45,
-            45,
-            45,
             10,
             27,
             97,
@@ -510,6 +488,171 @@ void main() {
             45,
             45,
             45,
+            10,
+            27,
+            77,
+            0,
+            10,
+            10,
+            10,
+            10,
+            29,
+            86,
+            0,
+            12
+          ]));
+    });
+
+    test('BytesPrinter (ESC/POS 1; font: b)', () async {
+      var profile = await CapabilityProfile.load();
+
+      final printer = BytesPrinter(PaperSize.mm80, profile);
+
+      var doc = _buildPrinterDocument1b();
+
+      doc.print(printer);
+
+      var printedBytes = printer.toBytes();
+
+      expect(printedBytes.length, greaterThan(10));
+
+      print("<<${latin1.decode(printedBytes)}>>");
+      print(printedBytes);
+
+      var decodedCommands = DecoderEscPos().decode(printedBytes);
+
+      var commandsJson = decodedCommands.toJson();
+      var decodedCommands2 = CommandEscPos.fromJsonList(commandsJson);
+      expect(decodedCommands2, decodedCommands);
+
+      expect(commandsJson, [
+        {'name': 'reset'},
+        {
+          'name': 'table',
+          'parameters': [0]
+        },
+        {
+          'name': 'font',
+          'parameters': ['b']
+        },
+        {
+          'name': 'align',
+          'parameters': ['left']
+        },
+        {
+          'name': 'font-size',
+          'parameters': [2, 2]
+        },
+        {
+          'name': 'text',
+          'parameters': ['Hello\n']
+        },
+        {
+          'name': 'align',
+          'parameters': ['right']
+        },
+        {
+          'name': 'bold',
+          'parameters': ['on']
+        },
+        {
+          'name': 'text',
+          'parameters': ['World!\n']
+        },
+        {
+          'name': 'align',
+          'parameters': ['left']
+        },
+        {
+          'name': 'bold',
+          'parameters': ['off']
+        },
+        {
+          'name': 'text',
+          'parameters': ['----------------------------\n']
+        },
+        {
+          'name': 'align',
+          'parameters': ['center']
+        },
+        {
+          'name': 'lines_spacing',
+          'parameters': [16]
+        },
+        {
+          'name': 'bit_image',
+          'parameters': [
+            33,
+            1,
+            0,
+            [128, 0, 0],
+            true
+          ]
+        },
+        {'name': 'lines_spacing:1/6'},
+        {
+          'name': 'align',
+          'parameters': ['left']
+        },
+        {
+          'name': 'text',
+          'parameters': [
+            '----------------------------\n'
+                '\n'
+                '\n'
+                '\n'
+                '\n'
+          ]
+        },
+        {
+          'name': 'cut',
+          'parameters': ['full']
+        },
+        {'name': 'end_job'}
+      ]);
+
+      expect(
+          printedBytes,
+          equals([
+            27,
+            64,
+            27,
+            116,
+            0,
+            27,
+            77,
+            1,
+            27,
+            97,
+            0,
+            29,
+            33,
+            17,
+            72,
+            101,
+            108,
+            108,
+            111,
+            10,
+            27,
+            97,
+            2,
+            27,
+            69,
+            1,
+            87,
+            111,
+            114,
+            108,
+            100,
+            33,
+            10,
+            27,
+            97,
+            0,
+            27,
+            69,
+            0,
             45,
             45,
             45,
@@ -540,8 +683,54 @@ void main() {
             45,
             10,
             27,
-            77,
+            97,
+            1,
+            27,
+            51,
+            16,
+            27,
+            42,
+            33,
+            1,
             0,
+            128,
+            0,
+            0,
+            10,
+            27,
+            50,
+            27,
+            97,
+            0,
+            45,
+            45,
+            45,
+            45,
+            45,
+            45,
+            45,
+            45,
+            45,
+            45,
+            45,
+            45,
+            45,
+            45,
+            45,
+            45,
+            45,
+            45,
+            45,
+            45,
+            45,
+            45,
+            45,
+            45,
+            45,
+            45,
+            45,
+            45,
+            10,
             10,
             10,
             10,
@@ -1723,6 +1912,28 @@ PrinterDocument _buildPrinterDocument1() {
   image.setPixel(0, 0, ColorRgba8(255, 0, 0, 255));
 
   var doc = PrinterDocument(fontSize: 2);
+
+  doc.addText(text: 'Hello', style: PrinterCommandStyle(align: PosAlign.left));
+
+  doc.addText(
+      text: 'World!',
+      style: PrinterCommandStyle(align: PosAlign.right, bold: true));
+
+  doc.addHR();
+
+  doc.addImage(image);
+
+  doc.addHR(style: PrinterCommandStyle(fontType: PosFontType.fontB));
+
+  doc.addCut();
+  return doc;
+}
+
+PrinterDocument _buildPrinterDocument1b() {
+  var image = Image(width: 1, height: 1, numChannels: 4);
+  image.setPixel(0, 0, ColorRgba8(255, 0, 0, 255));
+
+  var doc = PrinterDocument(fontSize: 2, fontType: 'b');
 
   doc.addText(text: 'Hello', style: PrinterCommandStyle(align: PosAlign.left));
 


### PR DESCRIPTION
- `PrinterDocument`:
  - Added `fontType` field with default `'a'`.
  - Updated constructor to accept `fontType` parameter, normalizing to lowercase and trimming.
  - Updated `fromJson` and `toJson` to include `fontType`.
  - Updated `print` method to apply `fontType` along with `fontSize` in styles and printer commands.

- `Generator`:
  - Updated `getCharsPerLine` to accept named parameters and apply font width scaling conditionally.
  - Updated `getCharWidth` to pass named parameter `maxCharsPerLine`.
  - Updated `hr` method to calculate line length considering font width scaling.